### PR TITLE
authorization

### DIFF
--- a/src/Apollo.js
+++ b/src/Apollo.js
@@ -6,7 +6,7 @@ import {
 } from "@apollo/client";
 import { setContext } from "@apollo/client/link/context";
 
-const TOKEN = "TOKEN";
+const TOKEN = "authorization";
 const DARK_MODE = "DARK_MODE";
 
 export const isLoggedInVar = makeVar(Boolean(localStorage.getItem(TOKEN)));
@@ -37,10 +37,11 @@ const httpLink = createHttpLink({
 
 //http header로 보내기 위해서 사용
 const authLink = setContext((_, { headers }) => {
+  const token = localStorage.getItem(TOKEN);
   return {
     headers: {
       ...headers,
-      token: localStorage.getItem(TOKEN)
+      authorization: token ? `Bearer ${token}` : ""
     }
   };
 });


### PR DESCRIPTION
cloning과 달리 DrawBy에서는 token 대신에 authorization을 사용.
이를 반영하여 localstorage에서 authorization을 읽어와 Bearer이라는 string과 함께 apollo server로 header를 넘겨준다.