### PR TITLE
kakao login 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12653,6 +12653,11 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
+    "react-kakao-login": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/react-kakao-login/-/react-kakao-login-2.1.0.tgz",
+      "integrity": "sha512-yvwe9Qc5cG+ucDAWOoIW4QjMB55M0Y97v040pbjcmc3Ud+bYHbQ+SwcVkOBvfDynyQbLPPoGJ+iN8rCRD4lzJw=="
+    },
     "react-refresh": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.8.3.tgz",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "react-facebook-login": "^4.1.1",
     "react-helmet": "^6.1.0",
     "react-hook-form": "^7.19.5",
+    "react-kakao-login": "^2.1.0",
     "react-router-dom": "^6.0.2",
     "react-scripts": "4.0.3",
     "styled-components": "^5.3.3",

--- a/src/auth/Facebook.js
+++ b/src/auth/Facebook.js
@@ -7,7 +7,7 @@ import { logUserIn } from "../Apollo";
 import routes from "../routes";
 
 const SOCIAL_LOGIN_MUTATION = gql`
-  mutation Mutation($socialId: String!, $email: String!) {
+  mutation Mutation($socialId: String!, $email: String) {
     socialLogin(socialId: $socialId, email: $email) {
       ok
       error

--- a/src/auth/Kakao.js
+++ b/src/auth/Kakao.js
@@ -1,0 +1,75 @@
+import React from "react";
+import styled from "styled-components";
+import KakaoLogin from "react-kakao-login";
+import gql from "graphql-tag";
+import { useNavigate } from "react-router";
+import { useMutation } from "@apollo/client";
+import routes from "../routes";
+import { logUserIn } from "../Apollo";
+
+const buttonBlock = {
+  border: "none",
+  borderRadius: "9px",
+  fontSize: "17px",
+  width: "284px",
+  fontWeight: "500",
+  height: "32px",
+  cursor: "pointer",
+  background: "#fae101",
+  alignItems: "center",
+  display: "flex",
+  justifyContent: "center",
+  padding: "4px 0px"
+};
+
+const ButtoninnerText = styled.h3`
+  margin: 0;
+  font-size: 14px;
+`;
+
+const SOCIAL_LOGIN_MUTATION = gql`
+  mutation Mutation($socialId: String!, $email: String) {
+    socialLogin(socialId: $socialId, email: $email) {
+      ok
+      error
+      token
+    }
+  }
+`;
+
+const Kakao = () => {
+  const navigate = useNavigate();
+  const [socialLogin] = useMutation(SOCIAL_LOGIN_MUTATION);
+  const oAuthLoginHandler = async response => {
+    const { email, id } = response.profile;
+    const {
+      data: {
+        socialLogin: { error, ok, token }
+      }
+    } = await socialLogin({ variables: { socialId: "id", email } });
+
+    if (error && !ok) {
+      navigate(routes.socialSignUp, {
+        state: { socialId: String(id), email }
+      });
+    }
+    if (ok) {
+      logUserIn(token);
+    }
+  };
+  return (
+    <>
+      <KakaoLogin
+        token="5a8e19e3b2f302ef50b5b0145d03c272"
+        buttonText="kakao"
+        onSuccess={oAuthLoginHandler}
+        onFail={console.error}
+        onLogout={console.info}
+        style={buttonBlock}
+      >
+        <ButtoninnerText>카카오 계정으로 로그인</ButtoninnerText>
+      </KakaoLogin>
+    </>
+  );
+};
+export default Kakao;

--- a/src/screens/Login.js
+++ b/src/screens/Login.js
@@ -7,6 +7,7 @@ import Input from "../auth/Input";
 import routes from "../routes";
 import { useLocation } from "react-router";
 import Facebook from "../auth/Facebook";
+import Kakao from "../auth/Kakao";
 const LOGIN_MUTATION = gql`
   mutation login($username: String!, $password: String!) {
     login(username: $username, password: $password) {
@@ -67,6 +68,7 @@ export default function Login() {
         <span>회원이 아니신가요?</span>
         <Link to={routes.signUp}>회원가입하기</Link>
         <Facebook />
+        <Kakao />
       </div>
     </div>
   );

--- a/src/screens/SocialSignUp.js
+++ b/src/screens/SocialSignUp.js
@@ -62,11 +62,12 @@ export default function SocialSignUp() {
     formState: { errors }
   } = useForm();
   const onValid = data => {
+    console.log(data, socialId);
     createAccount({
       variables: {
         ...data,
-        socialId,
-        email
+        socialId
+        // email
       }
     });
   };
@@ -80,6 +81,14 @@ export default function SocialSignUp() {
             required: "username이 필요합니다."
           })}
         />
+        {!email ? (
+          <Input
+            placeholder="email"
+            {...register("email", {
+              required: "email이 필요합니다."
+            })}
+          />
+        ) : null}
         <Input placeholder="phoneNumber" {...register("phoneNumber")} />
         <Input placeholder="avatar" {...register("avatar")} />
         <Input placeholder="bio" {...register("bio")} />


### PR DESCRIPTION
kakao login 구현 완료했음.

하지만 카카오 api에서 사용자 이메일을 반드시 받아오려면 business app으로 업그레이드 시켜야 한다고 함.
우리는 사업자가 없어서 불가능한 상태.

따라서 벡엔드를 조금 수정해서 social login 뮤테이션이 날아올 시에 email이 필수 필드가 아니도록 수정하고,
email이 없다면 에러를 리턴하도록 만들었음.

에러가 리턴된다면 똑같이 social siginup 페이지로 이동하되 state에 email값이 존재하지 않는다면 추가로 email 필드가 나타나도록 만들었음

ps. api key 노출돼서 헛짓거리함 !!! ㅜㅜ