### PR TITLE
Contest gallery

### DIFF
--- a/src/Layout.js
+++ b/src/Layout.js
@@ -20,6 +20,7 @@ const Feed = styled.div`
   background-color: ${props => (props.color ? props.color : "#fff")};
   position: relative;
   padding: 61px 400px;
+  min-height: 100vh;
 `;
 
 export default function Layout({ children }) {

--- a/src/Layout.js
+++ b/src/Layout.js
@@ -4,9 +4,7 @@ import styled from "styled-components";
 import Sidebar from "./Sidebar";
 
 const Main = styled.main`
-  background-color: ${props => (props.color ? props.color : "#fff")};
   display: flex;
-  min-height: 1000vh;
 `;
 
 const Line = styled.div`
@@ -19,9 +17,9 @@ const Line = styled.div`
 `;
 
 const Feed = styled.div`
-  position: absolute;
-  top: 61px;
-  left: 400px;
+  background-color: ${props => (props.color ? props.color : "#fff")};
+  position: relative;
+  padding: 61px 400px;
 `;
 
 export default function Layout({ children }) {
@@ -30,8 +28,8 @@ export default function Layout({ children }) {
       <Header />
       <Line />
       <Sidebar />
-      <Main color={children[0]}>
-        <Feed>{children[1]}</Feed>
+      <Main>
+        <Feed color={children[0]}>{children[1]}</Feed>
       </Main>
     </Fragment>
   );

--- a/src/components/ContestHeader.js
+++ b/src/components/ContestHeader.js
@@ -96,7 +96,8 @@ const SlideBtn = styled.img`
   width: 66px;
   height: 66px;
   position: absolute;
-  top: ${props => (props.y ? props.y : "108px")};
+  cursor: pointer;
+  top: ${props => (props.y ? props.y : "168px")};
   z-index: 1;
   left: ${props => props.x};
 `;
@@ -199,7 +200,7 @@ function ContestHeader({ customYear, customMonth, customWeekNo }) {
         {picturesLen > 4 && (
           <SlideBtn
             onClick={prevSlide}
-            x="-35px"
+            x="365px"
             src="/PictureSrc/LeftArrow.png"
           />
         )}
@@ -239,8 +240,8 @@ function ContestHeader({ customYear, customMonth, customWeekNo }) {
         {picturesLen > 4 && (
           <SlideBtn
             onClick={nextSlide}
-            x="650px"
-            y="113px"
+            x="1050px"
+            y="173px"
             src="/PictureSrc/RightArrow.png"
           />
         )}

--- a/src/screens/Home.js
+++ b/src/screens/Home.js
@@ -54,7 +54,6 @@ export default function Home() {
   const { data, loading, fetchMore } = useQuery(FEED_QUERY, {
     variables: { skip: 0, take: 5 }
   });
-  console.log(data);
   const onLoadMore = () => {
     fetchMore({
       variables: {

--- a/src/screens/UserProfile.js
+++ b/src/screens/UserProfile.js
@@ -124,6 +124,14 @@ const SEE_PROFILE_QUERY = gql`
         totalLike
         totalComment
       }
+      contestPictures {
+        id
+        caption
+        file
+        name
+        totalLike
+        totalComment
+      }
       isMe
       totalFollowers
       totalFollowings
@@ -196,7 +204,6 @@ function UserProfile() {
     });
 
   const unfollowUserUpdate = (cache, result) => {
-    console.log("here");
     const {
       data: {
         unfollowUser: { ok }
@@ -255,6 +262,21 @@ function UserProfile() {
     fetchMore({
       variables: {
         skip: data.seeProfile.pictures.length,
+        take: 12
+      },
+      updateQuery: (prev, { fetchMoreResult }) => {
+        if (!fetchMoreResult) return prev;
+        return Object.assign({}, prev, {
+          seeProfile: [...prev.seeProfile, ...fetchMoreResult.seeProfile]
+        });
+      }
+    });
+  };
+
+  const onLoadMoreContestPictures = () => {
+    fetchMore({
+      variables: {
+        skip: data.seeProfile.contestPictures.length,
         take: 12
       },
       updateQuery: (prev, { fetchMoreResult }) => {
@@ -365,6 +387,16 @@ function UserProfile() {
             style={{ height: "auto" }}
           >
             <Gallery pictures={data?.seeProfile?.pictures} />
+          </InfiniteScroll>
+        )}
+        {!loading && data && data.seeProfile && gallery === 1 && (
+          <InfiniteScroll
+            dataLength={data.seeProfile.contestPictures.length}
+            next={onLoadMoreContestPictures}
+            hasMore={true}
+            style={{ height: "auto" }}
+          >
+            <Gallery pictures={data?.seeProfile?.contestPictures} />
           </InfiniteScroll>
         )}
       </UserPictureContainer>

--- a/src/screens/UserProfile.js
+++ b/src/screens/UserProfile.js
@@ -298,7 +298,22 @@ function UserProfile() {
       updateQuery: (prev, { fetchMoreResult }) => {
         if (!fetchMoreResult) return prev;
         return Object.assign({}, prev, {
-          seeProfile: [...prev.seeProfile, ...fetchMoreResult.seeProfile]
+          seeProfile: {
+            id: prev.seeProfile.id,
+            username: prev.seeProfile.username,
+            email: prev.seeProfile.email,
+            avatar: prev.seeProfile.avatar,
+            bio: prev.seeProfile.bio,
+            pictures: prev.seeProfile.pictures,
+            isMe: prev.seeProfile.isMe,
+            totalFollowers: prev.seeProfile.totalFollowers,
+            totalFollowings: prev.seeProfile.totalFollowings,
+            isFollowing: prev.seeProfile.isFollowing,
+            contestPictures: [
+              ...prev.seeProfile.contestPictures,
+              ...fetchMoreResult.seeProfile.contestPictures
+            ]
+          }
         });
       }
     });
@@ -400,7 +415,6 @@ function UserProfile() {
             dataLength={data.seeProfile.pictures.length}
             next={onLoadMorePictures}
             hasMore={true}
-            // style={{ height: "auto" }}
           >
             <Gallery pictures={data?.seeProfile?.pictures} />
           </InfiniteScroll>
@@ -410,7 +424,6 @@ function UserProfile() {
             dataLength={data.seeProfile.contestPictures.length}
             next={onLoadMoreContestPictures}
             hasMore={true}
-            style={{ height: "auto" }}
           >
             <Gallery pictures={data?.seeProfile?.contestPictures} />
           </InfiniteScroll>

--- a/src/screens/UserProfile.js
+++ b/src/screens/UserProfile.js
@@ -110,13 +110,13 @@ const GalleryText = styled(FontSpan)`
 
 const SEE_PROFILE_QUERY = gql`
   query seeProfile($username: String!, $skip: Int!, $take: Int!) {
-    seeProfile(username: $username, skip: $skip, take: $take) {
+    seeProfile(username: $username) {
       id
       username
       email
       avatar
       bio
-      pictures {
+      pictures(skip: $skip, take: $take) {
         id
         caption
         file
@@ -261,13 +261,29 @@ function UserProfile() {
   const onLoadMorePictures = () => {
     fetchMore({
       variables: {
+        username,
         skip: data.seeProfile.pictures.length,
         take: 12
       },
       updateQuery: (prev, { fetchMoreResult }) => {
         if (!fetchMoreResult) return prev;
         return Object.assign({}, prev, {
-          seeProfile: [...prev.seeProfile, ...fetchMoreResult.seeProfile]
+          seeProfile: {
+            id: prev.seeProfile.id,
+            username: prev.seeProfile.username,
+            email: prev.seeProfile.email,
+            avatar: prev.seeProfile.avatar,
+            bio: prev.seeProfile.bio,
+            contestPictures: prev.seeProfile.contestPictures,
+            isMe: prev.seeProfile.isMe,
+            totalFollowers: prev.seeProfile.totalFollowers,
+            totalFollowings: prev.seeProfile.totalFollowings,
+            isFollowing: prev.seeProfile.isFollowing,
+            pictures: [
+              ...prev.seeProfile.pictures,
+              ...fetchMoreResult.seeProfile.pictures
+            ]
+          }
         });
       }
     });
@@ -384,7 +400,7 @@ function UserProfile() {
             dataLength={data.seeProfile.pictures.length}
             next={onLoadMorePictures}
             hasMore={true}
-            style={{ height: "auto" }}
+            // style={{ height: "auto" }}
           >
             <Gallery pictures={data?.seeProfile?.pictures} />
           </InfiniteScroll>


### PR DESCRIPTION
콘테스트 갤러리 구성
1. seeProfile 쿼리 (user 객체로 정보를 받아옴) 에서 pictures 필드와 contestPictures 필드를 pagination으로 받아올 수 있음.
2. pagination을 통해 무한 스크롤 가능 (기존의 목적대로 4*3 개씩 받아옴)

피드 배경화면과 유저 프로필 배경화면 색 차이 유지
- 이때 Layout에서 Main 컴포넌트의 height를 1000vh로 크게 부여하여 해결해왔는데, 피드에서는 그림의 크기가 크기때문에 문제 없었음.
- 프로필에서 갤러리 무한스크롤을 구현하며 1000vh만큼 스크롤을 내려야 로딩이 되어서 작은 그림이 많은 갤러리에서는 한참 스크롤을 내려야하는 문제 발생
- 이 문제를 Layout 컴포넌트를 수정하여 해결.