### PR TITLE
Hashtag search result

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -15,6 +15,7 @@ import ProfileEdit from "./screens/ProfileEdit";
 import Test from "./screens/infiniteTest";
 import ContestFeed from "./screens/ContestFeed";
 import HashtagFeed from "./screens/HashtagFeed";
+import GridPictures from "./components/GridPictures";
 
 function App() {
   const isLoggedIn = useReactiveVar(isLoggedInVar);
@@ -65,6 +66,15 @@ function App() {
                 <Layout>
                   {"#f1f2f3"}
                   <HashtagFeed />
+                </Layout>
+              }
+            />
+            <Route
+              path={routes.hashtagSearch}
+              element={
+                <Layout>
+                  {"#f1f2f3"}
+                  <GridPictures />
                 </Layout>
               }
             />

--- a/src/Header.js
+++ b/src/Header.js
@@ -190,6 +190,7 @@ export default function Header() {
               <Button src="/PictureSrc/DMHeader.png" />
               <UserIcon
                 onClick={toggleUserMenu}
+                style={{ cursor: "pointer" }}
                 size="36px"
                 src={data?.me?.avatar}
               />

--- a/src/components/Common/Avatar.js
+++ b/src/components/Common/Avatar.js
@@ -5,7 +5,6 @@ export const UserIcon = styled.img`
   width: ${props => (props.size ? props.size : "25px")};
   height: ${props => (props.size ? props.size : "25px")};
   border-radius: 50%;
-  cursor: pointer;
 `;
 // 유저 아바타 받아와서 표현해야함
 export default UserIcon;

--- a/src/components/Common/GridPictures.js
+++ b/src/components/Common/GridPictures.js
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 
 export const Grid = styled.div`
-  margin-top: 40px;
+  margin-top: 20px;
   display: grid;
   grid-auto-rows: ${props => (props.small ? "158.8px" : "213.3px")};
   grid-template-columns: ${props =>

--- a/src/components/DivisionLine.js
+++ b/src/components/DivisionLine.js
@@ -1,0 +1,9 @@
+import styled from "styled-components";
+
+export const DivisionLine = styled.div`
+  width: 680px;
+  height: 6px;
+  margin-top: 10px;
+  border-radius: 148px;
+  background-color: #eee;
+`;

--- a/src/components/GridPictures.js
+++ b/src/components/GridPictures.js
@@ -40,7 +40,7 @@ function GridPictures({ noTitle, contest }) {
     hashtagTopic =
       "#" + contestArr[0] + "_" + contestArr[1] + "_" + contestArr[2];
   } else {
-    hashtagTopic = hashtagName;
+    hashtagTopic = "#" + hashtagName;
   }
   const { data, loading, fetchMore } = useQuery(SEE_HASHTAG, {
     variables: { hashtagName: hashtagTopic, skip: 0, take: 12 }

--- a/src/components/Header/SearchBar.js
+++ b/src/components/Header/SearchBar.js
@@ -28,6 +28,7 @@ const SearchInput = styled.input`
   border: none;
   border-radius: 20%;
   background-color: inherit;
+  width: 90%;
   :focus {
     outline: none;
   }
@@ -62,6 +63,7 @@ const SearchResult = styled.div`
   margin-top: 10px;
   display: flex;
   align-items: center;
+  cursor: pointer;
 `;
 
 const SearchText = styled(Username)`
@@ -143,7 +145,7 @@ function SearchBox() {
   const goHashtag = hashtagName => {
     const hashtag = hashtagName.split("#")[1];
     setSearchModal(false);
-    navigate(`/hashtag/${hashtag}`);
+    navigate(`/hashtag/${hashtag}/search`);
   };
   const goPicture = () => {
     setSearchModal(false);

--- a/src/routes.js
+++ b/src/routes.js
@@ -7,6 +7,7 @@ const routes = {
   uploadPhoto: "/uploadPhoto",
   profile: "/profile/:username",
   hashtag: "/hashtag/:hashtagName",
+  hashtagSearch: "/hashtag/:hashtagName/search",
   contest: "/contest/:hashtagName",
   editProfile: "/profile/:username/edit"
 };

--- a/src/screens/ContestFeed.js
+++ b/src/screens/ContestFeed.js
@@ -1,6 +1,7 @@
 import React, { Fragment } from "react";
 import { useParams } from "react-router-dom";
 import ContestHeader from "../components/ContestHeader";
+import { DivisionLine } from "../components/DivisionLine";
 import GridPictures from "../components/GridPictures";
 
 function ContestFeed() {
@@ -13,6 +14,7 @@ function ContestFeed() {
         customMonth={contestArr[1]}
         customWeekNo={contestArr[2]}
       />
+      <DivisionLine />
       <GridPictures noTitle="true" contest="true" />
     </Fragment>
   );

--- a/src/screens/HashtagFeed.js
+++ b/src/screens/HashtagFeed.js
@@ -16,7 +16,7 @@ const HashtagTitle = styled(FontSpan)`
 `;
 
 const HashtagHeader = styled.div`
-  margin: 30px 0 16px;
+  margin: 30px 0 0px;
   display: flex;
   justify-content: space-between;
 `;

--- a/src/screens/SignUp.js
+++ b/src/screens/SignUp.js
@@ -7,6 +7,7 @@ import routes from "../routes";
 import { useNavigate } from "react-router";
 import styled from "styled-components";
 import { FontSpan, NoLineLink } from "../components/Common/Commons";
+import { CREATE_ACCOUNT_MUTATION } from "./SocialSignUp";
 
 const Background = styled.div`
   background-color: #fafafa;
@@ -84,28 +85,6 @@ const LoginLogo = styled.img`
   width: 350px;
   height: 300px;
   margin-bottom: 48px;
-`;
-const CREATE_ACCOUNT_MUTATION = gql`
-  mutation Mutation(
-    $username: String!
-    $password: String!
-    $email: String!
-    $phoneNumber: String
-    $avatar: String
-    $bio: String
-  ) {
-    createAccount(
-      username: $username
-      password: $password
-      email: $email
-      phoneNumber: $phoneNumber
-      avatar: $avatar
-      bio: $bio
-    ) {
-      ok
-      error
-    }
-  }
 `;
 
 export default function SignUp() {

--- a/src/screens/SocialSignUp.js
+++ b/src/screens/SocialSignUp.js
@@ -7,7 +7,7 @@ import routes from "../routes";
 import { useLocation, useNavigate } from "react-router";
 import { NoLineLink } from "../components/Common/Commons";
 
-const CREATE_ACCOUNT_MUTATION = gql`
+export const CREATE_ACCOUNT_MUTATION = gql`
   mutation Mutation(
     $username: String!
     $email: String!

--- a/src/screens/Upload.js
+++ b/src/screens/Upload.js
@@ -242,7 +242,6 @@ const Upload = ({ register: uploadRegister }) => {
         totalComment: 0,
         comments: []
       };
-      console.log(newPicture);
       const newCachePicture = cache.writeFragment({
         data: newPicture,
         fragment: gql`
@@ -303,7 +302,6 @@ const Upload = ({ register: uploadRegister }) => {
       onCompleted: result => onCompletedUploadPicture(result)
     });
   };
-  console.log(uploadContest);
 
   return (
     <BackGround>


### PR DESCRIPTION
해시태그 검색 후 해당 해시태그 페이지로 이동하면 해시태그 피드 페이지로 이동했음.
검색 결과로 해당 해시태그의 많은 그림들을 작게 보여주는 것이 더 의미있다고 판단하여 GridPictures를 적용하는 방향으로 수정

- 유저아이콘 cursor가 기본으로 포인터로 정해져있던 것을 삭제하고, 개별 적용함.
- 콘테스트 헤더와 갤러리를 구분하는 구분선 추가